### PR TITLE
Python3 Compatibily for data generation

### DIFF
--- a/data/not_so_clevr_generator.py
+++ b/data/not_so_clevr_generator.py
@@ -372,7 +372,7 @@ class dataset_writer(object):
         np_dict = {}
 
         np.random.seed(seed=MAGIC_SEED_OF_GREATNESS)
-        order = np.random.permutation(len(fields[fields.keys()[0]]))
+        order = np.random.permutation(len(fields[list(fields.keys())[0]]))
 
         for field in fields:
             np_dict[field] = np.array(fields[field])


### PR DESCRIPTION
In Python 3, dict.keys doesn't return a list, but something like a set that doesn't support indexing. To make indexing possible, it is necessary to convert that to a list.